### PR TITLE
Fix type for refreshing tokens

### DIFF
--- a/src/Provider/Basecamp.php
+++ b/src/Provider/Basecamp.php
@@ -61,7 +61,7 @@ class Basecamp extends AbstractProvider {
     public function getAccessToken($grant, array $options = []) {
 
         $defaultOptiosn = [
-            'type' => 'web_server'
+            'type' => $grant == 'refresh_token' ? 'refresh' : 'web_server'
         ];
 
         $newOptions = array_merge($defaultOptiosn, $options);


### PR DESCRIPTION
https://github.com/thephpleague/oauth2-client#refreshing-a-token
If `type=webserver`, then error `Required option not passed: "access_token"` is thrown